### PR TITLE
Make DB access async, add nanotime to debug, move mark to NameRecord.

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/wordbank/NameRecord.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/NameRecord.java
@@ -1,0 +1,65 @@
+package com.programmerdan.minecraft.wordbank;
+
+import com.programmerdan.minecraft.wordbank.data.WordBankData;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.logging.Level;
+
+/**
+ *
+ * @author caucow
+ */
+public class NameRecord {
+	public final String key;
+	public final String value;
+	private boolean marked;
+	
+	public NameRecord(String key, String value, boolean marked) {
+		this.key = Objects.requireNonNull(key);
+		this.value = Objects.requireNonNull(value);
+		this.marked = marked;
+	}
+	
+	/**
+	 * Marks the wordbank key/value pair as used in the database, along with
+	 * player UUID and the item type it was applied to. 
+	 * @param wbplugin WordBank plugin (for database access)
+	 * @param playerId player UUID
+	 * @param itemType item type name was applied to
+	 * @param force force a database update with the current pID and itemType
+	 * regardless of whether this name is already marked
+	 */
+	public void mark(WordBank wbplugin, String playerId, String itemType, boolean force) {
+		if (marked && !force) {
+			return;
+		}
+		marked = true;
+		if (wbplugin.config().hasDB()) {
+			try {
+				if (wbplugin.config().isDebug()) wbplugin.logger().info("  - Inserting item record");
+				long startTime = 0, endTime = 0;
+				startTime = System.nanoTime();
+				try (
+						Connection connection = wbplugin.data().getConnection();
+						PreparedStatement insert = connection.prepareStatement(WordBankData.insert)) {
+					insert.setString(1, key);
+					insert.setString(2, playerId);
+					insert.setString(3, itemType);
+					insert.setString(4, value);
+					insert.executeUpdate();
+					insert.close();
+					endTime = System.nanoTime();
+					if (wbplugin.config().isDebug()) wbplugin.logger().log(Level.INFO, "Wrote key/value {0}={1} to database in {2}ms", new Object[] { key, value, (endTime - startTime) / 1_000_000.0F });
+				}
+			} catch (SQLException se) {
+				wbplugin.logger().log(Level.WARNING, "Failed to insert key utilization", se);
+			}
+		}
+	}
+	
+	public boolean isMarked() {
+		return marked;
+	}
+}

--- a/src/main/java/com/programmerdan/minecraft/wordbank/WordBank.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/WordBank.java
@@ -1,5 +1,8 @@
 package com.programmerdan.minecraft.wordbank;
 
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
 import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -12,6 +15,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 import com.programmerdan.minecraft.wordbank.actions.ActionListener;
 import com.programmerdan.minecraft.wordbank.actions.CommandListener;
 import com.programmerdan.minecraft.wordbank.data.WordBankData;
+import com.programmerdan.minecraft.wordbank.util.NameConstructor;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.concurrent.TimeUnit;
+import org.bukkit.ChatColor;
 
 /**
  * See README.md for details. Simple Bukkit plugin using some Cool Stuff under the hood.
@@ -25,6 +34,7 @@ public class WordBank extends JavaPlugin {
 	private static WordBank plugin;
 	private WordBankConfig config;
 	private WordBankData data;
+	private LoadingCache<String, NameRecord> nameCache; // laggy database hits? that's not very cache money tbh
 
 	public void onEnable() {
 		WordBank.plugin = this;
@@ -40,6 +50,54 @@ public class WordBank extends JavaPlugin {
 		
 		// Do DB provision
 		data = new WordBankData();
+		nameCache = CacheBuilder.newBuilder()
+				.expireAfterAccess(config.getNamecacheInvalidateMinutes(), TimeUnit.MINUTES)
+				.expireAfterWrite(config.getNamecacheInvalidateMinutes(), TimeUnit.MINUTES)
+				.maximumSize(config.getNamecacheMaxSize())
+				.build(new CacheLoader<String, NameRecord>() {
+					@Override
+					public NameRecord load(String key) throws Exception {
+						String value = null;
+						long startTime = 0, endTime = 0;
+						if (config().hasDB()) {
+							try {
+								startTime = System.nanoTime();
+								try (Connection connection = data().getConnection();
+										PreparedStatement statement = connection.prepareStatement(WordBankData.getvalue)) {
+									statement.setString(1, key);
+									try (ResultSet rs = statement.executeQuery()) {
+										if (rs.next()) {
+											value = rs.getString("val");
+										}
+									}
+									statement.close();
+								}
+								endTime = System.nanoTime();
+							} catch (SQLException se) {
+								logger().log(Level.WARNING, "Failed to retrieve key/value data!", se);
+								if (config().isFailRenameOnDbError()) {
+									throw se;
+								}
+							}
+							if (value != null) {
+								// value exists in database, return record with marked=TRUE
+								NameRecord record = new NameRecord(key, value, true);
+								if (config().isDebug()) logger().log(Level.INFO, "Retrieved value {0}={1} from database in {2}ms", new Object[] { record.key, record.value, (endTime - startTime) / 1_000_000.0F });
+								return record;
+							} else {
+								// value did not exist in database. debug time and carry on
+								if (config().isDebug()) logger().log(Level.INFO, "Database entry not found for {0} in {1}ms", new Object[] { key, (endTime - startTime) / 1_000_000.0F });
+							}
+						}
+						// no value in database, return record with marked=FALSE
+						startTime = System.nanoTime();
+						NameRecord record = NameConstructor.buildName(key);
+						endTime = System.nanoTime();
+						if (config().isDebug()) logger().log(Level.INFO, "Generated name for value {0}={1} in {2}ms", new Object[] { record.key, record.value, (endTime - startTime) / 1_000_000.0F });
+						return record;
+					}
+				}
+		);
 		Bukkit.getPluginManager().registerEvents(new ActionListener(), this);
 		plugin.getCommand("wordbank").setExecutor(new CommandListener());
 	}
@@ -69,5 +127,9 @@ public class WordBank extends JavaPlugin {
 	}
 	public WordBankData data() {
 		return data;
+	}
+	
+	public LoadingCache<String, NameRecord> nameCache() {
+		return nameCache;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
@@ -33,7 +33,8 @@ public class WordBankConfig {
 	private boolean fail_rename_on_db_error;
 	private int namecache_invalidate_minutes;
 	private int namecache_max_size;
-	private boolean force_mark_all_renames;
+	private boolean dblog_all_item_marks;
+	private boolean prevent_dblookup_spam;
 	
 	public WordBankConfig(ConfigurationSection config) throws InvalidPluginException {
 		this(config, null);
@@ -79,7 +80,16 @@ public class WordBankConfig {
 		this.fail_rename_on_db_error = config.getBoolean("fail_rename_on_db_error", true);
 		this.namecache_invalidate_minutes = config.getInt("namecache_invalidate_minutes", 5);
 		this.namecache_max_size = config.getInt("namecache_max_size", 500);
-		this.force_mark_all_renames = config.getBoolean("force_mark_all_renames", false);
+		// Before the change to use async load/generate, every time a player
+		// used wordbank to generate a name for an item, it added a new entry to
+		// the database regardless of whether an entry already existed with that
+		// wbkey. Setting this to true will keep that old behavior (for...
+		// counting number of times a name is used or something? idk)
+		this.dblog_all_item_marks = config.getBoolean("dblog_all_item_marks", false);
+		// Set to true if players are spamming wordbank too fast and slowing the
+		// database. Defaulting this to false for now since it *shouldn't* really
+		// be a big problem, but leaving the option there.
+		this.prevent_dblookup_spam = config.getBoolean("prevent_dblookup_spam", true);
 		
 		// dbconfig 
 		this.db_config = null;
@@ -176,7 +186,11 @@ public class WordBankConfig {
 		return namecache_max_size;
 	}
 	
-	public boolean getForceMarkAllRenames() {
-		return force_mark_all_renames;
+	public boolean isDBLogAllItemMarks() {
+		return dblog_all_item_marks;
+	}
+	
+	public boolean isPreventDBLookupSpam() {
+		return prevent_dblookup_spam;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
@@ -30,6 +30,9 @@ public class WordBankConfig {
 	private boolean debug;
 	private WordBank plugin;
 	private long confirm_delay;
+	private boolean fail_rename_on_db_error;
+	private int namecache_invalidate_minutes;
+	private int namecache_max_size;
 	
 	public WordBankConfig(ConfigurationSection config) throws InvalidPluginException {
 		this(config, null);
@@ -67,6 +70,14 @@ public class WordBankConfig {
 		}
 		
 		this.confirm_delay = config.getLong("confirm_delay", 10000l);
+		
+		// true if, should the database be enabled AND throw an exception when
+		// getting a value for a key name, wordbank should skip trying to generate
+		// a new value for that key (prevents possible ambiguity in names if
+		// the configs change and the che cache can't access the database)
+		this.fail_rename_on_db_error = config.getBoolean("fail_rename_on_db_error", true);
+		this.namecache_invalidate_minutes = config.getInt("namecache_invalidate_minutes", 5);
+		this.namecache_max_size = config.getInt("namecache_max_size", 500);
 		
 		// dbconfig 
 		this.db_config = null;
@@ -149,5 +160,17 @@ public class WordBankConfig {
 	
 	public HikariConfig database() {
 		return this.db_config;
+	}
+	
+	public boolean isFailRenameOnDbError() {
+		return fail_rename_on_db_error;
+	}
+	
+	public int getNamecacheInvalidateMinutes() {
+		return namecache_invalidate_minutes;
+	}
+	
+	public int getNamecacheMaxSize() {
+		return namecache_max_size;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
@@ -87,8 +87,7 @@ public class WordBankConfig {
 		// counting number of times a name is used or something? idk)
 		this.dblog_all_item_marks = config.getBoolean("dblog_all_item_marks", false);
 		// Set to true if players are spamming wordbank too fast and slowing the
-		// database. Defaulting this to false for now since it *shouldn't* really
-		// be a big problem, but leaving the option there.
+		// database.
 		this.prevent_dblookup_spam = config.getBoolean("prevent_dblookup_spam", true);
 		
 		// dbconfig 

--- a/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/WordBankConfig.java
@@ -33,6 +33,7 @@ public class WordBankConfig {
 	private boolean fail_rename_on_db_error;
 	private int namecache_invalidate_minutes;
 	private int namecache_max_size;
+	private boolean force_mark_all_renames;
 	
 	public WordBankConfig(ConfigurationSection config) throws InvalidPluginException {
 		this(config, null);
@@ -78,6 +79,7 @@ public class WordBankConfig {
 		this.fail_rename_on_db_error = config.getBoolean("fail_rename_on_db_error", true);
 		this.namecache_invalidate_minutes = config.getInt("namecache_invalidate_minutes", 5);
 		this.namecache_max_size = config.getInt("namecache_max_size", 500);
+		this.force_mark_all_renames = config.getBoolean("force_mark_all_renames", false);
 		
 		// dbconfig 
 		this.db_config = null;
@@ -172,5 +174,9 @@ public class WordBankConfig {
 	
 	public int getNamecacheMaxSize() {
 		return namecache_max_size;
+	}
+	
+	public boolean getForceMarkAllRenames() {
+		return force_mark_all_renames;
 	}
 }

--- a/src/main/java/com/programmerdan/minecraft/wordbank/actions/ActionListener.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/actions/ActionListener.java
@@ -1,9 +1,6 @@
 package com.programmerdan.minecraft.wordbank.actions;
 
 import com.programmerdan.minecraft.wordbank.NameRecord;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -180,7 +177,7 @@ public class ActionListener implements Listener {
 							// force=true for... logging purposes? to the database for some reason?
 							// why does it need player UUID and item type just to keep a unique key/value?
 							Bukkit.getScheduler().runTaskAsynchronously(plugin(), () -> {
-								newNameRecord.mark(plugin(), event.getPlayer().getUniqueId().toString(), item.getType().toString(), true);
+								newNameRecord.mark(plugin(), event.getPlayer().getUniqueId().toString(), item.getType().toString(), plugin().config().getForceMarkAllRenames());
 							});
 						} catch (Exception e) {
 							plugin().logger().log(Level.WARNING, "Something went very wrong while renaming", e);

--- a/src/main/java/com/programmerdan/minecraft/wordbank/data/WordBankData.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/data/WordBankData.java
@@ -36,6 +36,9 @@ public class WordBankData {
 			"SELECT uuid, count(*) AS cnt, count(DISTINCT target) AS targets " +
 			"  FROM wordbank_utilization WHERE wbkey = ? GROUP BY uuid LIMIT ? OFFSET ?;";
 	
+	public static final String getvalue =
+			"SELECT wbkey, wbname AS val FROM wordbank_utilization WHERE wbkey = ? LIMIT 1;";
+	
 	private HikariDataSource datasource;
 	
 	private WordBank plugin;

--- a/src/main/java/com/programmerdan/minecraft/wordbank/util/NameConstructor.java
+++ b/src/main/java/com/programmerdan/minecraft/wordbank/util/NameConstructor.java
@@ -1,6 +1,7 @@
 package com.programmerdan.minecraft.wordbank.util;
 
 import com.programmerdan.minecraft.wordbank.CharConfig;
+import com.programmerdan.minecraft.wordbank.NameRecord;
 import com.programmerdan.minecraft.wordbank.WordBank;
 
 /**
@@ -18,11 +19,10 @@ public class NameConstructor {
 	 * All these parts are joined and returned.
 	 * 
 	 * @param key The character sequence used to construct a WordBank name.
-	 * @param mark If true, save key as used; otherwise, do not.
 	 * @return The converted key.
 	 */
-	public static String buildName(String key, boolean mark) {
-		return buildName(key, mark, WordBank.instance());
+	public static NameRecord buildName(String key) {
+		return buildName(key, WordBank.instance());
 	}
 
 	/**
@@ -30,8 +30,7 @@ public class NameConstructor {
 	 * 
 	 * @param plugin the WordBank instance to use. Good for unit testing.
 	 */
-	public static String buildName(String key, boolean mark, WordBank plugin) {
-		// TODO: add mark storage; mark is ignored for now, tbd.
+	public static NameRecord buildName(String key, WordBank plugin) {
 		
 		// First, compute color.
 		float whichColor = executeConfig(plugin.config().getColor(), key);
@@ -51,7 +50,7 @@ public class NameConstructor {
 				));
 		}
 		
-		return name.toString();
+		return new NameRecord(key, name.toString(), false);
 	}
 	
 	public static float executeConfig(CharConfig conf, String key) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,13 @@ padding: 'â'
 add_serial: false
 makers_mark: "Marked Item"
 debug: false
+namecache_invalidate_minutes: 5
+namecache_max_size: 500
+prevent_dblookup_spam: true
+# Generally leave this false to keep the database clean
+dblog_all_item_marks: false
+# Leave this true to prevent wordlist changes from <maybe> breaking old renames
+fail_rename_on_db_error: true
 db:
   driver: mysql
   host: localhost


### PR DESCRIPTION
Used bukkit scheduler + guava loadingcache to make name loading/generation/storage async
Added 3 config options (only present in code, not config.yml) to configure the cache
Added time measuring debug to the name loading/generation/storage

I wasn't sure whether the player ID/item type was being written to the database for logging purposes so "mark"ing a name as used (and including the name/item) is still done for every wordbanked item. That can be safely disabled by calling NameRecord.mark with force=false on line 183 of ActionListener.